### PR TITLE
Updated MaxTweetLength constant to 280

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/ThirdParty/TWTRTwitterText.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/ThirdParty/TWTRTwitterText.m
@@ -240,7 +240,7 @@
 
 #pragma mark - Constants
 
-static const NSUInteger MaxTweetLength = 140;
+static const NSUInteger MaxTweetLength = 280;
 static const NSUInteger HTTPShortURLLength = 23;
 static const NSUInteger HTTPSShortURLLength = 23;
 


### PR DESCRIPTION
Problem

Twitter recently updated the max tweet length from 140 to 280 characters.

Solution

Updated the `MaxTweetLength` constant to 280. It seems there's only one reference to 140 in the repo, but you'll want to test before merging with the master.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.